### PR TITLE
Set torch num threads to 2 instead of autodetect

### DIFF
--- a/configs/eval.yaml
+++ b/configs/eval.yaml
@@ -43,5 +43,8 @@ test: True
 ckpt_path: null
 state_dict_hf_path: null
 
+# globally set torch.set_num_threads a good default is 2
+torch_num_threads: 2
+
 # seed for random number generators in pytorch, numpy and python.random
 seed: null

--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -39,5 +39,8 @@ tags: ["dev"]
 # simply provide checkpoint path to resume training
 ckpt_path: null
 
+# globally set torch.set_num_threads a good default is 2
+torch_num_threads: 2
+
 # seed for random number generators in pytorch, numpy and python.random
 seed: null

--- a/src/eval.py
+++ b/src/eval.py
@@ -70,6 +70,9 @@ def eval(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     # set seed for random number generators in pytorch, numpy and python.random
     if cfg.get("seed"):
         L.seed_everything(cfg.seed, workers=True)
+        
+    if cfg.get("torch_num_threads"):
+        torch.set_num_threads(cfg.torch_num_threads)
 
     log.info(f"Instantiating datamodule <{cfg.data._target_}>")
     datamodule: LightningDataModule = hydra.utils.instantiate(cfg.data)

--- a/src/self_refine.py
+++ b/src/self_refine.py
@@ -58,6 +58,9 @@ def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     # set seed for random number generators in pytorch, numpy and python.random
     if cfg.get("seed"):
         L.seed_everything(cfg.seed, workers=True)
+        
+    if cfg.get("torch_num_threads"):
+        torch.set_num_threads(cfg.torch_num_threads)
 
     log.info(f"Instantiating datamodule <{cfg.data._target_}>")
     datamodule: LightningDataModule = hydra.utils.instantiate(cfg.data)

--- a/src/train.py
+++ b/src/train.py
@@ -69,6 +69,9 @@ def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     if cfg.get("seed"):
         L.seed_everything(cfg.seed, workers=True)
 
+    if cfg.get("torch_num_threads"):
+        torch.set_num_threads(cfg.torch_num_threads)
+
     log.info(f"Instantiating datamodule <{cfg.data._target_}>")
     datamodule: LightningDataModule = hydra.utils.instantiate(cfg.data)
 


### PR DESCRIPTION
Addresses #11 
For torch operations in the dataloader which occur on cpu, torch automatically detects number of cpus to use as threads. This means each dataloader tries to get number of cpus threads to do each matmul. This can create a large number of unnecessary threads greatly slowing things down. Up to 10x speedup because of this line.