### PR TITLE
Fix ddp seeding

### DIFF
--- a/src/transferable_samplers/models/base_lightning_module.py
+++ b/src/transferable_samplers/models/base_lightning_module.py
@@ -15,6 +15,7 @@ from transferable_samplers.callbacks.ema_weight_averaging import EMAWeightAverag
 from transferable_samplers.models.buffer import Buffer
 from transferable_samplers.models.priors.prior import Prior
 from transferable_samplers.utils.dataclasses import SourceEnergy, SourceEnergyConfig, SystemCond
+from transferable_samplers.utils.dist_utils import drift_rng_state
 from transferable_samplers.utils.pylogger import RankedLogger
 
 logger = RankedLogger(__name__, rank_zero_only=False)
@@ -136,6 +137,11 @@ class BaseLightningModule(LightningModule):
 
         Optionally compiles the network and validates trainer batch limits.
         """
+        # Desync per-rank RNG once DDP is up. seed_everything seeds every rank
+        # identically, which makes rank-local draws (e.g. source_energy.sample)
+        # produce duplicate proposals across ranks.
+        drift_rng_state()
+
         if self.compile_net and stage == "fit":
             # pyrefly: ignore [bad-assignment]
             self.net = torch.compile(self.net)

--- a/src/transferable_samplers/utils/dist_utils.py
+++ b/src/transferable_samplers/utils/dist_utils.py
@@ -23,6 +23,32 @@ def get_rank() -> int:
     return dist.get_rank() if dist.is_initialized() else 0
 
 
+def drift_rng_state(stride: int = 10_000) -> None:
+    """Desync the per-rank RNG by consuming `rank * stride` random draws.
+
+    Lightning's ``seed_everything`` sets the same seed on every rank, which
+    causes rank-local sampling ops (e.g. ``source_energy.sample`` drawing
+    from a normalising-flow base distribution) to produce identical outputs
+    across ranks. Calling this once after DDP is initialised consumes a
+    rank-dependent number of random draws so subsequent draws decorrelate.
+    No-op on rank 0 / non-distributed.
+
+    Drifts CPU and (if available) every CUDA device's RNG. PyTorch's CPU
+    and CUDA RNGs are independent generators, and code paths that look
+    GPU-only often sample on CPU then move to GPU (e.g.
+    ``torch.distributions.Normal`` with scalar params), so we have to
+    advance both to be safe.
+    """
+    rank = get_rank()
+    if rank == 0:
+        return
+    n = rank * stride
+    torch.randn(n)
+    if torch.cuda.is_available():
+        for i in range(torch.cuda.device_count()):
+            torch.randn(n, device=torch.device("cuda", i))
+
+
 def all_gather_cat(tensor: torch.Tensor) -> torch.Tensor:
     """All-gather a tensor across ranks and concatenate along dim 0.
 

--- a/src/transferable_samplers/utils/dist_utils.py
+++ b/src/transferable_samplers/utils/dist_utils.py
@@ -23,29 +23,42 @@ def get_rank() -> int:
     return dist.get_rank() if dist.is_initialized() else 0
 
 
-def drift_rng_state(stride: int = 10_000) -> None:
-    """Desync the per-rank RNG by consuming `rank * stride` random draws.
+def drift_rng_state() -> None:
+    """Desync the per-rank RNG by seeking each rank's generators to a unique offset.
 
     Lightning's ``seed_everything`` sets the same seed on every rank, which
     causes rank-local sampling ops (e.g. ``source_energy.sample`` drawing
     from a normalising-flow base distribution) to produce identical outputs
-    across ranks. Calling this once after DDP is initialised consumes a
-    rank-dependent number of random draws so subsequent draws decorrelate.
+    across ranks. Calling this once after DDP is initialised advances each
+    rank's RNG by ``rank * STRIDE``, so subsequent draws decorrelate.
     No-op on rank 0 / non-distributed.
 
     Drifts CPU and (if available) the current CUDA device's RNG. PyTorch's
     CPU and CUDA RNGs are independent generators, and code paths that look
     GPU-only often sample on CPU then move to GPU (e.g.
     ``torch.distributions.Normal`` with scalar params), so we have to
-    advance both to be safe.
+    advance both.
+
+    CUDA uses a counter-based Philox generator, so we seek directly via
+    ``Generator.set_offset`` rather than burning kernel launches — note that
+    ``torch.randn(N, device=cuda)`` advances the offset by a fixed amount
+    *per launch*, not per element, so a single big call would not decorrelate
+    ranks. CPU's Mersenne Twister has no cheap seek, but it advances per
+    element, so a single ``torch.randn(rank * STRIDE)`` is fine.
+
+    STRIDE is chosen so each rank gets a sub-stream large enough to never
+    collide in practice: ~10^6 launches/elements per rank gap, well above
+    any realistic per-rank RNG consumption in a single run, and a tiny
+    fraction of Philox's 2^64 offset space.
     """
+    STRIDE = 1 << 20
     rank = get_rank()
     if rank == 0:
         return
-    n = rank * stride
-    torch.randn(n)
+    torch.randn(rank * STRIDE)
     if torch.cuda.is_available():
-        torch.randn(n, device=torch.cuda.current_device())
+        gen = torch.cuda.default_generators[torch.cuda.current_device()]
+        gen.set_offset(gen.get_offset() + rank * STRIDE)
 
 
 def all_gather_cat(tensor: torch.Tensor) -> torch.Tensor:

--- a/src/transferable_samplers/utils/dist_utils.py
+++ b/src/transferable_samplers/utils/dist_utils.py
@@ -33,8 +33,8 @@ def drift_rng_state(stride: int = 10_000) -> None:
     rank-dependent number of random draws so subsequent draws decorrelate.
     No-op on rank 0 / non-distributed.
 
-    Drifts CPU and (if available) every CUDA device's RNG. PyTorch's CPU
-    and CUDA RNGs are independent generators, and code paths that look
+    Drifts CPU and (if available) the current CUDA device's RNG. PyTorch's
+    CPU and CUDA RNGs are independent generators, and code paths that look
     GPU-only often sample on CPU then move to GPU (e.g.
     ``torch.distributions.Normal`` with scalar params), so we have to
     advance both to be safe.
@@ -45,8 +45,7 @@ def drift_rng_state(stride: int = 10_000) -> None:
     n = rank * stride
     torch.randn(n)
     if torch.cuda.is_available():
-        for i in range(torch.cuda.device_count()):
-            torch.randn(n, device=torch.device("cuda", i))
+        torch.randn(n, device=torch.cuda.current_device())
 
 
 def all_gather_cat(tensor: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
Current code on main will have zero diversity across ranks when `seed=` is passed in.

This means training e.g flow matching noise, and sampling e.g proposal sampling is identical across ranks. This is probably non-critical for the flow matching as the data _is_ shuffled correctly across ranks by lightning internals. For sampling this is catastrophic as it reduces the number of unique particles by `/world_size`.

I tried doing some per-rank `lightning.seed_everything` calls but had issues - DDP isn't initalized at this point. An alternative would be to re-seed in lightning module setup, but this could mean diversity is lost between e.g train and test (perhaps unlikely to be an issue, but a scary footgun to introduce). In the end I've opted to just "drift" the RNG state during lightning module setup. This should be both 1. reproducible and 2. create psuedo-unique RNG states between workers. 3. not have the above footgun of fixing the seed every time `setup` is called.

Happy to discuss, but for now this has resolved the issue in my dev branch.

