### PR TITLE
Update test workflow

### DIFF
--- a/.github/workflows/essential-tests.yaml
+++ b/.github/workflows/essential-tests.yaml
@@ -2,7 +2,7 @@ name: Essential Tests (CPU)
 on:
   workflow_dispatch:
   pull_request:
-    types: [ready_for_review]
+    types: [opened, synchronize, reopened]
     branches: [main]
 jobs:
   essential-tests:


### PR DESCRIPTION
The previous `ready_for_review` trigger doesn't apply to PRs created with reviewers assigned at the start.